### PR TITLE
Remove rashification.

### DIFF
--- a/geoip2.gemspec
+++ b/geoip2.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'faraday'
   spec.add_dependency 'typhoeus'
   spec.add_dependency 'faraday_middleware'
-  spec.add_dependency 'rash'
   spec.add_dependency 'activesupport'
+  spec.add_dependency 'hashie'
 end

--- a/lib/geoip2/client.rb
+++ b/lib/geoip2/client.rb
@@ -75,8 +75,8 @@ module Geoip2
 
         conn.request :basic_auth, @user, @password
 
-        # Set the response to be rashified
-        conn.response :rashify
+        # Set the response to be mashified
+        conn.response :mashify
 
         # Setting request and response to use JSON/XML
         conn.request :json

--- a/spec/api/country_spec.rb
+++ b/spec/api/country_spec.rb
@@ -8,7 +8,7 @@ describe Geoip2::Api::Country do
       end
     end
     subject { @response }
-    it { should be_a ::Hashie::Rash }
+    it { should be_a ::Hashie::Mash }
     it { should respond_to :country }
     it { should respond_to :continent }
     it { should respond_to :registered_country }
@@ -22,7 +22,7 @@ describe Geoip2::Api::Country do
 
     it /has a names array in country/ do
       expect(subject.country).to include :names
-      expect(subject.country.names).to be_a ::Hashie::Rash
+      expect(subject.country.names).to be_a ::Hashie::Mash
     end
 
     it /has a 'en' name and it's value should be Israel/ do


### PR DESCRIPTION
Up to you if you want to merge this, but the `rash` dependency prevents people from upgrading to hashie >= 2.1.0.

See https://github.com/tcocca/rash/issues/9 for context.
